### PR TITLE
feat: add 'data-wrap', 'data-line-nos' and 'data-expand' attribute

### DIFF
--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -2,8 +2,11 @@ import { default as params } from '@params';
 import snackbar from 'mods/snackbar/js/index.ts';
 import i18n from './i18n';
 
-const isTrue = (val: string | null): boolean => {
-    return !val && val !== 'false' && val !== '0'
+const isTrue = (val: string | boolean): boolean => {
+    if (typeof val === 'boolean') {
+        return val
+    }
+    return val !== '' && val !== 'false' && val !== '0'
 }
 
 export default class Panel {

--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -34,6 +34,8 @@ export default class Panel {
 
         this.maxLines()
         this.title()
+        this.wrap()
+        this.lineNo()
         this.lineNoButton()
         this.wrapButton()
         this.expandButton()
@@ -108,6 +110,13 @@ export default class Panel {
         this.ele.appendChild(btn)
     }
 
+    private wrap() {
+        const wrap = this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap
+        if (wrap) {
+            this.code.classList.add('code-wrap')
+        }
+    }
+
     private toggleClass(className: string) {
 
         if (this.code.classList.contains(className)) {
@@ -123,6 +132,13 @@ export default class Panel {
             this.toggleClass('code-no-ln')
         })
         this.ele.appendChild(btn)
+    }
+
+    private lineNo() {
+        const lineNos = this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos
+        if (lineNos) {
+            this.code.classList.add('code-no-ln')
+        }
     }
 
     private expandButton() {

--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -34,8 +34,9 @@ export default class Panel {
 
         this.maxLines()
         this.title()
-        this.wrap()
-        this.lineNo()
+        this.wrapCheck()
+        this.lineNoCheck()
+        this.expandCheck()
         this.lineNoButton()
         this.wrapButton()
         this.expandButton()
@@ -49,7 +50,7 @@ export default class Panel {
         return Array.from(this.code.querySelectorAll(':scope > span'))
     }
 
-    private maxHeight
+    private maxHeight: string
 
     private maxLines() {
         const lines = this.lines()
@@ -110,7 +111,7 @@ export default class Panel {
         this.ele.appendChild(btn)
     }
 
-    private wrap() {
+    private wrapCheck() {
         const wrap = this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap
         if (wrap) {
             this.code.classList.add('code-wrap')
@@ -134,7 +135,7 @@ export default class Panel {
         this.ele.appendChild(btn)
     }
 
-    private lineNo() {
+    private lineNoCheck() {
         const lineNos = this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos
         if (lineNos) {
             this.code.classList.add('code-no-ln')
@@ -146,6 +147,13 @@ export default class Panel {
             this.expand()
         })
         this.ele.appendChild(btn)
+    }
+
+    private expandCheck() {
+        const expand = this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand
+        if (expand) {
+            this.expand()
+        }
     }
 
     private expand() {

--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -15,13 +15,17 @@ export default class Panel {
     }
 
     init() {
-        if (!this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos)) {
+        const isTrue = (val: boolean | string): boolean => {
+            return !!val && val !== 'false' && val !== '0'
+        }
+
+        if (!isTrue(this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos)) {
             this.code.classList.add('code-no-ln')
         }
-        if (this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap)) {
+        if (isTrue(this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap)) {
             this.code.classList.add('code-wrap')
         }
-        if (this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand)) {
+        if (isTrue(this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand)) {
             this.expand()
         }
 
@@ -61,10 +65,6 @@ export default class Panel {
                 this.pre.style.maxHeight = this.maxHeight = offsetTop + 'px'
             }
         }
-    }
-
-    private toBoolean(val: boolean | string) {
-        return val && val !== 'false' && val !== '0'
     }
 
     // Display the title

--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -2,6 +2,10 @@ import { default as params } from '@params';
 import snackbar from 'mods/snackbar/js/index.ts';
 import i18n from './i18n';
 
+const isTrue = (val: string | null): boolean => {
+    return !val && val !== 'false' && val !== '0'
+}
+
 export default class Panel {
     private highlight: HTMLElement
 
@@ -15,17 +19,14 @@ export default class Panel {
     }
 
     init() {
-        const isTrue = (val: boolean | string): boolean => {
-            return !!val && val !== 'false' && val !== '0'
-        }
-
-        if (!isTrue(this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos)) {
+        const highlight = this.code.closest('.highlight')
+        if (!isTrue(highlight?.getAttribute('data-line-nos') ?? params.line_nos)) {
             this.code.classList.add('code-no-ln')
         }
-        if (isTrue(this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap)) {
+        if (isTrue(highlight?.getAttribute('data-wrap') ?? params.wrap)) {
             this.code.classList.add('code-wrap')
         }
-        if (isTrue(this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand)) {
+        if (isTrue(highlight?.getAttribute('data-expand') ?? params.expand)) {
             this.expand()
         }
 

--- a/assets/mods/code-block-panel/js/panel.ts
+++ b/assets/mods/code-block-panel/js/panel.ts
@@ -15,11 +15,14 @@ export default class Panel {
     }
 
     init() {
-        if (!params.line_nos) {
+        if (!this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos)) {
             this.code.classList.add('code-no-ln')
         }
-        if (params.wrap) {
+        if (this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap)) {
             this.code.classList.add('code-wrap')
+        }
+        if (this.toBoolean(this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand)) {
+            this.expand()
         }
 
         this.pre = this.code.parentElement as HTMLElement
@@ -34,9 +37,6 @@ export default class Panel {
 
         this.maxLines()
         this.title()
-        this.wrapCheck()
-        this.lineNoCheck()
-        this.expandCheck()
         this.lineNoButton()
         this.wrapButton()
         this.expandButton()
@@ -61,6 +61,10 @@ export default class Panel {
                 this.pre.style.maxHeight = this.maxHeight = offsetTop + 'px'
             }
         }
+    }
+
+    private toBoolean(val: boolean | string) {
+        return val && val !== 'false' && val !== '0'
     }
 
     // Display the title
@@ -111,13 +115,6 @@ export default class Panel {
         this.ele.appendChild(btn)
     }
 
-    private wrapCheck() {
-        const wrap = this.code.closest('.highlight')?.getAttribute('data-wrap') ?? params.wrap
-        if (wrap) {
-            this.code.classList.add('code-wrap')
-        }
-    }
-
     private toggleClass(className: string) {
 
         if (this.code.classList.contains(className)) {
@@ -135,25 +132,11 @@ export default class Panel {
         this.ele.appendChild(btn)
     }
 
-    private lineNoCheck() {
-        const lineNos = this.code.closest('.highlight')?.getAttribute('data-line-nos') ?? params.line_nos
-        if (lineNos) {
-            this.code.classList.add('code-no-ln')
-        }
-    }
-
     private expandButton() {
         const btn = this.button('expand', () => {
             this.expand()
         })
         this.ele.appendChild(btn)
-    }
-
-    private expandCheck() {
-        const expand = this.code.closest('.highlight')?.getAttribute('data-expand') ?? params.expand
-        if (expand) {
-            this.expand()
-        }
     }
 
     private expand() {

--- a/layouts/partials/code-block-panel/assets/js-resource.html
+++ b/layouts/partials/code-block-panel/assets/js-resource.html
@@ -8,6 +8,7 @@
   "max_lines" 10
   "line_nos" true
   "wrap" false
+  "expand" false
 }}
 {{- $i18n := newScratch }}
 {{- $sites := .Sites }}


### PR DESCRIPTION
<pre><code>
```plaintext {data-wrap=true,data-line-nos=true,data-expand=true}
--add-modules=jdk.incubator.vector -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M -XX:G1ReservePercent=20
```
</code></pre>

`data-wrap=true` will wrap the code of the code block by default.
`data-line-nos=false` will remove line number of the code block by default.
`data-expand=true` will expand the code block by default.

I'm not sure if I did it right... At least, it worked in my local test.

May close #27 
